### PR TITLE
Restricting max number of options to 25

### DIFF
--- a/utils/airTableCalls.ts
+++ b/utils/airTableCalls.ts
@@ -184,6 +184,7 @@ export function readLookup(table: Table<FieldSet>): Promise<LookupItem[]> {
   return new Promise((resolve, reject) => {
     const items: LookupItem[] = [];
     table.select({
+      maxRecords: 25,
       sort: [{ field: 'Name', direction: 'asc' }],
     }).eachPage(function page(records, fetchNextPage) {
       records.forEach(record => {


### PR DESCRIPTION
Now that we have allowed more than 10 items to be loaded into the select options, we have it a maximum limit of 25.