### PR TITLE
Adding Heroku Deployment workflow

### DIFF
--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -6,8 +6,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/heroku-deploy.yml
+++ b/.github/workflows/heroku-deploy.yml
@@ -1,0 +1,28 @@
+
+name: Deploy To Heroku
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+# .github/workflows/heroku-deploy.yml
+jobs:
+  heroku-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Deploy to Heroku
+        uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}


### PR DESCRIPTION
This workflow should be able to deploy the bot to Heroku when new changes are committed to the main branch.
We still need to get the secrets setup, before we can test it.

If someone can create the following secrets, I can then supply the values to go into them.

```
secrets.HEROKU_API_KEY
secrets.HEROKU_APP_NAME
secrets.HEROKU_EMAIL
```

I would also like to know if we can run the other workflow for testing and linting as part of this one, or before this one runs.
